### PR TITLE
fix: offer to use collection instead of tenant

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,9 +51,9 @@ interface Offer {
   aggregate: PieceCID
   // CID of all the segments part of the aggregate
   pieces: PieceCID[]
-  // identifier of the tenant for the storefront `did:web:web3.storage`
-  // spade relies on tenant naming, so we map it here to tenant
-  tenant: string
+  // identifier of the collection for the tenant `did:web:web3.storage`
+  // spade relies on collections to identify different replication constraints.
+  collection: string
   // enables ordering of offers to handle.
   // Being it the number of ms since epoch, also means offers that fail and are retried will have "priority"
   // It can also have lower numbers to prioritize certain actors in the future

--- a/packages/core/src/data/offer.ts
+++ b/packages/core/src/data/offer.ts
@@ -20,7 +20,7 @@ export const encode = {
     const value = {
       aggregate: dealRecord.aggregate.toString(),
       pieces: dealRecord.pieces.map(p => p.toString()),
-      tenant: dealRecord.storefront,
+      collection: dealRecord.storefront,
       orderID: dealRecord.insertedAt || Date.now()
     } satisfies Offer
 
@@ -53,7 +53,7 @@ export const decode = {
     return {
       aggregate: parseLink(record.aggregate),
       pieces: record.pieces.map(p => parseLink(p)),
-      storefront: record.tenant,
+      storefront: record.collection,
       insertedAt: record.orderID
     }
   },
@@ -74,6 +74,6 @@ export type EncodedRecord = {
 export type Offer = {
   aggregate: string
   pieces: string[]
-  tenant: string
+  collection: string
   orderID: number
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -94,7 +94,7 @@ test('POST /', async t => {
   const encodedOffer = JSON.parse(toString(bucketItem))
 
   t.is(encodedOffer.aggregate, aggregate.link.link().toString())
-  t.is(encodedOffer.tenant, invocationConfig.with)
+  t.is(encodedOffer.collection, invocationConfig.with)
   t.truthy(encodedOffer.orderID)
   t.deepEqual(encodedOffer.pieces, offer.map(o => o.toString()))
 })


### PR DESCRIPTION
Previously we were building assuming that we could use one bucket and set the `tenant` ID as the way to integrate with Spade.  This approach would also be tricky in future scenarios where we wanted to have the ability to have different configurations per SLA things (in case it materializes).

Talking with @jcace ([SEE](https://filecoinproject.slack.com/archives/C05C7CUPEKX/p1694413792026369)) about `storefront` property and whether we could rely on a friendly name (e.g. `did:web:web3.storage`) instead of an internal ID, we concluded that Spade would require a different bucket per tenant. However, each tenant MAY have different collections with different Replication Constraints.

We were asked to have different buckets per tenant, and swap `tenant` into `collection`. For now, we will also actually just have one tenant, so we can figure out later how could we have dynamic tenant world without needing to manually provision a bucket.